### PR TITLE
Feat: update from RFCs pull 263 spec to pull 271

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # CLP Packet
 > Codec for Common Ledger Protocol messages
 
-This implements the encoding for the CLP protocol as defined [in the latest pull request](https://github.com/interledger/rfcs/pull/263). CLP does not yet have a first draft yet, so this is a WIP.
+This implements the encoding for the CLP protocol as defined [in the latest pull request](https://github.com/interledger/rfcs/pull/271). CLP does not yet have a first draft yet, so this is a WIP.


### PR DESCRIPTION
- Add CLP error type
- Remove CLP custom request/response
- sideData -> protocolData
- Remove ILP packet from prepare, message, and response
- add MIME types for protocolData, and use an array instead of a map